### PR TITLE
Add disc command to slashCommander

### DIFF
--- a/commands/disc.mjs
+++ b/commands/disc.mjs
@@ -1,0 +1,57 @@
+import Discogs from 'disconnect';
+
+const CLIENT_USER_AGENT = 'MuseBot/1.0';
+
+function getDiscogsClient(userAgent = CLIENT_USER_AGENT) {
+  return new Discogs.Client(userAgent, { userToken: process.env.DISCOGS }).database();
+}
+
+function isValidRelease(release) {
+  const format = release.format;
+  const required = ['Album', 'Single', 'Compilation', 'LP', 'EP', 'Shellac'];
+  const forbidden = ['Unofficial Release', 'Promo', 'Test Pressing', 'TP', 'Jukebox']
+
+  return required.some((type) => format.includes(type)) && !forbidden.some((type) => format.includes(type));
+}
+
+function formatResult(result, title, url) {
+  if (!result || !result.year) {
+    throw Error(`No match. [Discogs Search](${url.href})`);
+  }
+
+  return {
+    title: `${result.title} (${result.year})`,
+    description: `${title}\n\n${(result.genre || []).join(', ')} (${(result.style || []).join(', ')})`,
+    image: { url: result.cover_image },
+    url: getMasterUrl(result.master_id),
+    fields: [{ name: '\u200b', value: `[Discogs Search](${url})` }],
+  };
+}
+
+const getMasterUrl = (master_id) => `https://www.discogs.com/master/${master_id}`;
+
+export default async function disc(artist, title) {
+  const disc = getDiscogsClient();
+
+  const url = new URL('https://www.discogs.com/search/');
+  url.search = new URLSearchParams({
+    artist,
+    title,
+    type: 'release',
+    sort: 'year,asc',
+    layout: 'sm',
+  })
+
+  const sortFn = (x, y) => x.year - y.year || y.community.have - x.community.have;
+
+  const data = await disc.search({
+    artist,
+    title,
+    type: 'release',
+    sort: 'year',
+    sort_order: 'asc',
+  });
+
+  const results = data.results.sort(sortFn).filter(isValidRelease);
+  return formatResult(results[0], title, url.href);
+}

--- a/commands/slash-commander.mjs
+++ b/commands/slash-commander.mjs
@@ -35,7 +35,7 @@ export default class SlashCommander {
       },
       disc: {
         handler: 'disc',
-        global: false,
+        global: true,
         channels: ['music', 'music-meta', 'skynet'],
         name: 'disc',
         description: 'Returns the earliest year of the specified track according to Discogs.',
@@ -102,7 +102,12 @@ export default class SlashCommander {
     if (typeof config === 'undefined') {
       throw new Error(`Unknown command '${command}'`);
     }
-    if (config.global || !config.channels) {
+    if (config.global && !interaction.guildId) {
+      // Interaction from a DM
+      // Always allowed for global commands
+      return true;
+    }
+    if (!config.channels) {
       // All channels allowed
       return true;
     }

--- a/commands/slash-commander.mjs
+++ b/commands/slash-commander.mjs
@@ -1,4 +1,5 @@
 import tzstamp from './tzstamp.mjs';
+import disc from './disc.mjs';
 
 export default class SlashCommander {
   static get CONFIG() {
@@ -29,6 +30,27 @@ export default class SlashCommander {
             description: 'Return the timestamp code in a codeblock.',
             required: false,
             defaultValue: false,
+          },
+        ],
+      },
+      disc: {
+        handler: 'disc',
+        global: false,
+        channels: ['music', 'music-meta', 'skynet'],
+        name: 'disc',
+        description: 'Returns the earliest year of the specified track according to Discogs.',
+        options: [
+          {
+            name: 'artist',
+            type: 'STRING',
+            description: 'The artist to search for.',
+            required: true,
+          },
+          {
+            name: 'title',
+            type: 'STRING',
+            description: 'The track to search for.',
+            required: true,
           },
         ],
       },
@@ -75,6 +97,7 @@ export default class SlashCommander {
   }
 
   isValidChannel(command, interaction) {
+    this.logger.debug({ command, interaction }, 'Testing for valid channel');
     const config = SlashCommander.CONFIG[command];
     if (typeof config === 'undefined') {
       throw new Error(`Unknown command '${command}'`);
@@ -88,7 +111,7 @@ export default class SlashCommander {
       return false;
     }
     return config.channels.some(
-      (channelName) => this.client[channelName].id === interaction.channel.id,
+      (channelName) => this.client.client.channels.cache.get(interaction.channel.id).name === channelName,
     );
   }
 
@@ -157,7 +180,7 @@ export default class SlashCommander {
         this.logger.debug(`Not handling command '${interaction.commandName}'`);
         return;
       }
-      if (!this.isValidChannel(interaction.commandName, interaction.channel)) {
+      if (!this.isValidChannel(interaction.commandName, interaction)) {
         this.logger.debug(`Not handling command '${interaction.commandName}' in channel ${interaction.channel?.id}`);
         return;
       }
@@ -203,6 +226,31 @@ export default class SlashCommander {
         args = ['2022/01/03 16:50'];
       }
       this.logger.info(tzstamp(...args));
+    }
+  }
+
+  async disc(interaction, args) {
+    if (interaction) {
+      this.logger.debug({ args }, 'Handling disc command.');
+      let response = "";
+      try {
+        response = await disc(...args);
+      } catch (e) {
+        response = e.message;
+      }
+      this.logger.debug({ args, response }, 'Replying to disc command.');
+      await interaction.reply({embeds: [response]});
+    } else {
+      this.logger.info({ args }, 'Testing disc.');
+      if (args.length === 2) {
+        try {
+          this.logger.info(await disc(...args));
+        } catch (e) {
+          this.logger.info(e.message);
+        }
+      } else {
+        this.logger.error('Incorrect number of arguments given. Artist and title are required.');
+      }
     }
   }
 


### PR DESCRIPTION
Test with e.g.

```
./main.mjs -tv slashTest disc 'Daft Punk' 'Around the World'
```

Should only need to add `disc` onto the end of the commands used to have it handle `tzstamp`, so:
```
./main.mjs -v slashCreate disc
```
and in `pm2` have it run
```
./main.mjs -v slashStart tzstamp disc
```