### PR TITLE
Super Duper Fun

### DIFF
--- a/seeding/tests/test64.csv
+++ b/seeding/tests/test64.csv
@@ -1,65 +1,65 @@
-"artist","song","submitter","seed","link"
-"Band A (featuring Band D)","Song 1","alpha",1,"https://example.com/1"
-"Band B","Song 2","alpha",2,"https://example.com/2"
-"Band C","Song 3","alpha",3,"https://example.com/3"
-"Band D","Song 4","alpha",4,"https://example.com/4"
-"Band E","Song 5","alpha",5,"https://example.com/5"
-"Band F","Song 6","beta",1,"https://example.com/6"
-"Band F","Song 7","beta",2,"https://example.com/7"
-"Band G","Song 8","beta",3,"https://example.com/8"
-"Band G","Song 9","beta",4,"https://example.com/9"
-"Band H","Song 10","beta",5,"https://example.com/10"
-"Band A","Song 11","gamma",1,"https://example.com/11"
-"Band B","Song 12","gamma",2,"https://example.com/12"
-"Band I","Song 13","gamma",3,"https://example.com/13"
-"Band J","Song 14","gamma",4,"https://example.com/14"
-"Band E","Song 15","gamma",5,"https://example.com/15"
-"Band K","Song 16","delta",1,"https://example.com/16"
-"Band L","Song 17","delta",2,"https://example.com/17"
-"BAND A","Song 18","delta",3,"https://example.com/18"
-"Band M","Song 19","delta",4,"https://example.com/19"
-"Band N","Song 20","delta",5,"https://example.com/20"
-"Band B ft. Band A","Song 21","epsilon",1,"https://example.com/21"
-"Band B","Song 22","epsilon",2,"https://example.com/22"
-"Band C","Song 23","epsilon",3,"https://example.com/23"
-"Band O","Song 24","epsilon",4,"https://example.com/24"
-"Band P","Song 25","zeta",1,"https://example.com/25"
-"Band D","Song 26","zeta",2,"https://example.com/26"
-"Band D","Song 27","zeta",3,"https://example.com/27"
-"Band Q","Song 28","zeta",4,"https://example.com/28"
-"Band E","Song 29","eta",1,"https://example.com/29"
-"Báñd A","Song 30","eta",2,"https://example.com/30"
-"Band I","Song 31","eta",3,"https://example.com/31"
-"Band R","Song 32","eta",4,"https://example.com/32"
-"Band S","Song 33","theta",1,"https://example.com/33"
-"Band T","Song 34","theta",2,"https://example.com/34"
-"Band U","Song 35","theta",3,"https://example.com/35"
-"Band V","Song 36","theta",4,"https://example.com/36"
-"Band N","Song 37","iota",1,"https://example.com/37"
-"Band M","Song 38","iota",2,"https://example.com/38"
-"Band L","Song 39","iota",3,"https://example.com/39"
-"Band W","Song 40","iota",4,"https://example.com/40"
-"Band X","Song 41","kappa",1,"https://example.com/41"
-"Band Y","Song 42","kappa",2,"https://example.com/42"
-"Band U","Song 43","kappa",3,"https://example.com/43"
-"Band Z","Song 44","kappa",4,"https://example.com/44"
-"Band P","Song 45","lambda",1,"https://example.com/45"
-"Band N","Song 46","lambda",2,"https://example.com/46"
-"Band AA","Song 47","lambda",3,"https://example.com/47"
-"Band E","Song 48","lambda",4,"https://example.com/48"
-"Band AB","Song 49","mu",1,"https://example.com/49"
-"Band AC","Song 50","mu",2,"https://example.com/50"
-"Band AA","Song 51","mu",3,"https://example.com/51"
-"Band O","Song 52","mu",4,"https://example.com/52"
-"Band AD","Song 53","nu",1,"https://example.com/53"
-"Band AE","Song 54","nu",2,"https://example.com/54"
-"Band AF","Song 55","nu",3,"https://example.com/55"
-"Band C","Song 56","nu",4,"https://example.com/56"
-"Band AG","Song 57","xi",1,"https://example.com/57"
-"Band AH","Song 58","xi",2,"https://example.com/58"
-"Band AI","Song 59","xi",3,"https://example.com/59"
-"Band AI","Song 60","xi",4,"https://example.com/60"
-"Band Q","Song 61","omicron",1,"https://example.com/61"
-"the band ä","Song 62","omicron",2,"https://example.com/62"
-"Band E","Song 63","omicron",3,"https://example.com/63"
-"Band Q","Song 64","omicron",4,"https://example.com/64"
+"artist","song","submitter","seed","link","submitters"
+"Band A (featuring Band D)","Song 1","alpha",1,"https://example.com/1","alpha; beta"
+"Band B","Song 2","alpha",2,"https://example.com/2","alpha; beta"
+"Band C","Song 3","alpha",3,"https://example.com/3","alpha; beta"
+"Band D","Song 4","alpha",4,"https://example.com/4","alpha; beta"
+"Band E","Song 5","alpha",5,"https://example.com/5","alpha; beta"
+"Band F","Song 6","beta",1,"https://example.com/6","alpha; beta"
+"Band F","Song 7","beta",2,"https://example.com/7","alpha; beta"
+"Band G","Song 8","beta",3,"https://example.com/8","alpha; beta"
+"Band G","Song 9","beta",4,"https://example.com/9","alpha; beta"
+"Band H","Song 10","beta",5,"https://example.com/10","alpha; beta"
+"Band A","Song 11","gamma",1,"https://example.com/11",
+"Band B","Song 12","gamma",2,"https://example.com/12","beta; gamma"
+"Band I","Song 13","gamma",3,"https://example.com/13",
+"Band J","Song 14","gamma",4,"https://example.com/14",
+"Band E","Song 15","gamma",5,"https://example.com/15",
+"Band K","Song 16","delta",1,"https://example.com/16",
+"Band L","Song 17","delta",2,"https://example.com/17",
+"BAND A","Song 18","delta",3,"https://example.com/18",
+"Band M","Song 19","delta",4,"https://example.com/19",
+"Band N","Song 20","delta",5,"https://example.com/20",
+"Band B ft. Band A","Song 21","epsilon",1,"https://example.com/21",
+"Band B","Song 22","epsilon",2,"https://example.com/22",
+"Band C","Song 23","epsilon",3,"https://example.com/23",
+"Band O","Song 24","epsilon",4,"https://example.com/24",
+"Band P","Song 25","zeta",1,"https://example.com/25","alpha; zeta; iota"
+"Band D","Song 26","zeta",2,"https://example.com/26",
+"Band D","Song 27","zeta",3,"https://example.com/27",
+"Band Q","Song 28","zeta",4,"https://example.com/28",
+"Band E","Song 29","eta",1,"https://example.com/29",
+"Báñd A","Song 30","eta",2,"https://example.com/30",
+"Band I","Song 31","eta",3,"https://example.com/31",
+"Band R","Song 32","eta",4,"https://example.com/32",
+"Band S","Song 33","theta",1,"https://example.com/33",
+"Band T","Song 34","theta",2,"https://example.com/34",
+"Band U","Song 35","theta",3,"https://example.com/35",
+"Band V","Song 36","theta",4,"https://example.com/36",
+"Band N","Song 37","iota",1,"https://example.com/37",
+"Band M","Song 38","iota",2,"https://example.com/38",
+"Band L","Song 39","iota",3,"https://example.com/39",
+"Band W","Song 40","iota",4,"https://example.com/40",
+"Band X","Song 41","kappa",1,"https://example.com/41",
+"Band Y","Song 42","kappa",2,"https://example.com/42",
+"Band U","Song 43","kappa",3,"https://example.com/43",
+"Band Z","Song 44","kappa",4,"https://example.com/44",
+"Band P","Song 45","lambda",1,"https://example.com/45",
+"Band N","Song 46","lambda",2,"https://example.com/46",
+"Band AA","Song 47","lambda",3,"https://example.com/47",
+"Band E","Song 48","lambda",4,"https://example.com/48",
+"Band AB","Song 49","mu",1,"https://example.com/49",
+"Band AC","Song 50","mu",2,"https://example.com/50",
+"Band AA","Song 51","mu",3,"https://example.com/51",
+"Band O","Song 52","mu",4,"https://example.com/52",
+"Band AD","Song 53","nu",1,"https://example.com/53",
+"Band AE","Song 54","nu",2,"https://example.com/54",
+"Band AF","Song 55","nu",3,"https://example.com/55",
+"Band C","Song 56","nu",4,"https://example.com/56",
+"Band AG","Song 57","xi",1,"https://example.com/57",
+"Band AH","Song 58","xi",2,"https://example.com/58",
+"Band AI","Song 59","xi",3,"https://example.com/59",
+"Band AI","Song 60","xi",4,"https://example.com/60",
+"Band Q","Song 61","omicron",1,"https://example.com/61",
+"the band ä","Song 62","omicron",2,"https://example.com/62",
+"Band E","Song 63","omicron",3,"https://example.com/63",
+"Band Q","Song 64","omicron",4,"https://example.com/64",


### PR DESCRIPTION
Adds two options:
- `--badness-duper` for setting how much weight to give to early dupe collisions (default 20)
- `--drop-dupes-first` for prioritizing dropping submissions from submitters
  with more songs already in (default `false`)

These should work pretty well as is, but `--badness-duper` defaults to 20
(which is the same as artist collisions). It will scale down based on both the
number of dupes someone has and the number of people who submitted a song.

This looked alright to me, but could maybe use tweaking.

The warning output now mentions any submitter/dupe collisions within the first
two rounds.

TODO: Also add some badness for two dupes from the same submitter (but owned
by different people) colliding too early, and warnings to go with it.