### PR TITLE
Add random seed argument

### DIFF
--- a/seeding/seed.py
+++ b/seeding/seed.py
@@ -1139,7 +1139,7 @@ def output_seeded_csv(file, seeds, data, use_tabs, order, dropped):
     writer.writerows(ordered_data)
 
 
-def write_csv_data(csv_path, force, seeds, data, use_tabs, use_bracket_order, dropped):
+def write_csv_data(csv_path, force, seeds, data, use_tabs, output_order, dropped):
     """
     Given an output path and force flag, sorts data by seeds and writes it.
 
@@ -1155,7 +1155,7 @@ def write_csv_data(csv_path, force, seeds, data, use_tabs, use_bracket_order, dr
     """
 
     if csv_path is None:
-        return output_seeded_csv(sys.stdout, seeds, data, use_tabs, use_bracket_order, dropped)
+        return output_seeded_csv(sys.stdout, seeds, data, use_tabs, output_order, dropped)
 
     if force:
         dirs = os.path.dirname(csv_path)
@@ -1165,7 +1165,7 @@ def write_csv_data(csv_path, force, seeds, data, use_tabs, use_bracket_order, dr
     mode = "w" if force else "x"
 
     with open(csv_path, mode, newline="") as csv_file:
-        return output_seeded_csv(csv_file, seeds, data, use_tabs, use_bracket_order, dropped)
+        return output_seeded_csv(csv_file, seeds, data, use_tabs, output_order, dropped)
 
 
 def main(
@@ -1173,7 +1173,7 @@ def main(
     output_csv_path,
     force_output,
     output_csv_tabs,
-    output_bracket_order,
+    output_order,
     output_dropped,
     drop_dupes_first,
 ):
@@ -1187,6 +1187,11 @@ def main(
     :param output_csv_path: Path to output CSV file, or ``None`` for STDOUT
     :param force_output: If output file already exists overwrite it, if
         intermediate directories on the path do not exist, create them
+    :param output_csv_tabs: Output tabs instead of commas to separate tabular
+        fields
+    :param output_order: Order to print output lines in
+    :param output_dropped: Whether or not to include dropped submissions in the
+        output
     :param drop_dupes_first: Prioritize dropping songs by submitters with dupes
     :returns: None
     """
@@ -1200,7 +1205,7 @@ def main(
         seeds,
         data,
         output_csv_tabs,
-        output_bracket_order,
+        output_order,
         dropped if output_dropped else None,
     )
 

--- a/seeding/seed.py
+++ b/seeding/seed.py
@@ -913,6 +913,11 @@ def get_parser():
         default=ATTEMPT_ITERATIONS,
         type=int,
     )
+    group.add_argument(
+        "--random-seed",
+        help="value to seed Python's random module with",
+        default=None,
+    )
 
     return parser
 
@@ -1168,6 +1173,18 @@ def write_csv_data(csv_path, force, seeds, data, use_tabs, output_order, dropped
         return output_seeded_csv(csv_file, seeds, data, use_tabs, output_order, dropped)
 
 
+def seed_rng(seed):
+    if seed is None:
+        print("Using default RNG seed")
+        return
+    try:
+        seed = int(seed)
+        print(f"Seeding RNG with integer {seed}")
+    except ValueError:
+        print(f"Seeding RNG with string '{seed}'")
+    random.seed(seed)
+
+
 def main(
     input_csv_path,
     output_csv_path,
@@ -1176,6 +1193,7 @@ def main(
     output_order,
     output_dropped,
     drop_dupes_first,
+    random_seed=None,
 ):
     """
     Main entry point for the script.
@@ -1193,9 +1211,12 @@ def main(
     :param output_dropped: Whether or not to include dropped submissions in the
         output
     :param drop_dupes_first: Prioritize dropping songs by submitters with dupes
+    :param random_seed: If given, a string or integer to use as a seed for the
+        RNG before dropping any songs or populating bracket
     :returns: None
     """
 
+    seed_rng(random_seed)
     data = get_csv_data(input_csv_path)
     data, dropped = choose_submissions(data, drop_dupes_first)
     seeds = get_seed_order(data)
@@ -1217,6 +1238,7 @@ if __name__ == "__main__":
     output_csv_path = args.OUTPUT
     force_output = args.force
     drop_dupes_first = args.drop_dupes_first
+    random_seed = args.random_seed
 
     output_csv_tabs = args.output_csv_tabs
     output_order = args.output_order
@@ -1239,4 +1261,5 @@ if __name__ == "__main__":
         output_order,
         output_dropped,
         drop_dupes_first,
+        random_seed,
     )


### PR DESCRIPTION
Adds a `--random-seed` argument, which can be given any string (or, therefore, integer) to use to seed the RNG. This will allow us to have reproducible results given the same inputs.

To test various badness scores for things, try with `--attempts 0 --iterations 2000` and whatever `--random-seed` you like. You'll likely end up with a bunch of warnings since it will be kind of stuck with what it started on. Note that I set `attempts` to 0 because there's a "feature" where it's 0-indexed.