### PR TITLE
Tweak default options

### DIFF
--- a/seeding/csv_tools.py
+++ b/seeding/csv_tools.py
@@ -396,8 +396,8 @@ def add_output_parser_group(parser):
     group.add_argument(
         "--output-csv-tabs",
         help="use a tab delimiter when outputting the CSV data",
-        action="store_true",
-        default=False,
+        action=utils.BooleanOptionalAction,
+        default=True,
     )
     group.add_argument(
         "--output-order",
@@ -411,7 +411,7 @@ def add_output_parser_group(parser):
             f"the same as the input data."
         ),
         choices=Order.all(),
-        default=Order.SORTED,
+        default=Order.BRACKET,
     )
     group.add_argument(
         "--output-dropped",
@@ -420,8 +420,8 @@ def add_output_parser_group(parser):
             f"have an empty value for the new seed position. In `{Order.SORTED}` "
             f"output order, dropped submissions will be at the end."
         ),
-        action="store_true",
-        default=False,
+        action=utils.BooleanOptionalAction,
+        default=True,
     )
     return group
 

--- a/seeding/csv_tools.py
+++ b/seeding/csv_tools.py
@@ -348,9 +348,10 @@ def get_dropped(seeds, data):
     new_data = data.copy()
     dropped = []
 
-    for i, seed in seeds:
+    for i, seed in enumerate(seeds):
         if seed >= size:
-            dropped.append((i, seed + 1, new_data.pop(i)))
+            dropped.append((i, seed + 1, data[i]))
+            new_data.remove(data[i])
     new_seeds = [seed for seed in seeds if seed < size]
 
     return new_seeds, new_data, dropped

--- a/seeding/seed.py
+++ b/seeding/seed.py
@@ -7,6 +7,7 @@ import itertools
 import math
 import os
 import random
+import time
 
 import analysis
 import csv_tools
@@ -391,13 +392,14 @@ def choose_submissions(data, drop_dupes_first=False):
 
 def seed_rng(seed):
     if seed is None:
-        print("Using default RNG seed")
-        return
-    try:
-        seed = int(seed)
-        print(f"Seeding RNG with integer {seed}")
-    except ValueError:
-        print(f"Seeding RNG with string '{seed}'")
+        seed = int(time.time())
+        print(f"No seed set, using current timestamp {seed}")
+    else:
+        try:
+            seed = int(seed)
+            print(f"Seeding RNG with integer {seed}")
+        except ValueError:
+            print(f"Seeding RNG with string '{seed}'")
     random.seed(seed)
 
 

--- a/seeding/seed.py
+++ b/seeding/seed.py
@@ -422,8 +422,8 @@ def get_parser():
             "prioritize dropping songs submitted by people with more dupes "
             "first"
         ),
-        action="store_true",
-        default=False,
+        action=utils.BooleanOptionalAction,
+        default=True,
     )
 
     csv_tools.add_output_parser_group(parser)

--- a/seeding/utils.py
+++ b/seeding/utils.py
@@ -1,9 +1,11 @@
-import re
+import argparse
 import itertools
 import math
+import re
 import unicodedata
 
 __all__ = (
+    "BooleanOptionalAction",
     "chunk",
     "get_bracket_size",
     "get_canonical_artist",
@@ -15,6 +17,50 @@ __all__ = (
     "insert_byes",
     "invert_list",
 )
+
+
+# Grabbed from 3.9+ Python source
+# https://github.com/python/cpython/blob/9877f4c6249ac7f374dc48beaf21ea2bf3ee6996/Lib/argparse.py#L878-L914
+# TODO When upgrading to 3.9+ drop this and use it from `argparse` module directly
+class BooleanOptionalAction(argparse.Action):
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        default=None,
+        type=None,
+        choices=None,
+        required=False,
+        help=None,
+        metavar=None,
+    ):
+
+        _option_strings = []
+        for option_string in option_strings:
+            _option_strings.append(option_string)
+
+            if option_string.startswith('--'):
+                option_string = '--no-' + option_string[2:]
+                _option_strings.append(option_string)
+
+        super().__init__(
+            option_strings=_option_strings,
+            dest=dest,
+            nargs=0,
+            default=default,
+            type=type,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if option_string in self.option_strings:
+            setattr(namespace, self.dest, not option_string.startswith('--no-'))
+
+    def format_usage(self):
+        return ' | '.join(self.option_strings)
 
 
 # https://stackoverflow.com/a/22045226

--- a/seeding/utils.py
+++ b/seeding/utils.py
@@ -1,6 +1,7 @@
 import argparse
 import itertools
 import math
+import random
 import re
 import unicodedata
 


### PR DESCRIPTION
Should be a little easier to run now probably need something like

```
./seed.py input.csv output.csv
```

If you want to change the options that are now true by default (e.g. `--output-csv-tabs`) to be off, you can use `no-` in front of the option, so `--no-output-csv-tabs` will switch back to using commas instead of tabs.